### PR TITLE
Add active_admin_jcropper processor only once per attached file

### DIFF
--- a/lib/active_admin_jcrop/asset_engine/paperclip.rb
+++ b/lib/active_admin_jcrop/asset_engine/paperclip.rb
@@ -18,9 +18,12 @@ module Paperclip
     def has_attached_file(*args)
       super
 
-      self.attachment_definitions.each do |name, options|
-        options[:processors] ||= []
-        options[:processors] << :active_admin_jcropper
+      attribute_name = args[0]
+      definition = attachment_definitions[attribute_name]
+      definition[:processors] ||= []
+
+      unless definition[:processors].include?(:active_admin_jcropper)
+        definition[:processors] << :active_admin_jcropper
       end
     end
   end


### PR DESCRIPTION
When the model has multiple paperclip attributes, some loop in "has_attached_file" method runs more than once for every attached file.
Multiple processors on one attached file causes paperclip to process (and, therefore, crop) them more than once.
