### PR TITLE
Add ActiveAdmin namespace to jcropper_url only if not blank

### DIFF
--- a/app/views/active_admin_jcrop/_jcrop_modal.html.erb
+++ b/app/views/active_admin_jcrop/_jcrop_modal.html.erb
@@ -4,10 +4,10 @@
   <center>
     <div class="crop_modal_dimensions"></div>
     <%= image_tag object.send(field).url, class: 'cropping_image', data: {
-      object_class: object.class.to_s.underscore, 
-      object_id: object.id, 
+      object_class: object.class.to_s.underscore,
+      object_id: object.id,
       crop_field: field,
-jcropper_url: send("jcropper_#{ActiveAdmin.application.default_namespace.to_s}_#{object.class.to_s.demodulize.underscore}_path", object),
+      jcropper_url: jcropper_url(object) ,
       translate_save_cropped_image: I18n.t("active_admin.crop.save_cropped_image").titleize,
       translate_cancel: I18n.t("active_admin.crop.cancel").titleize,
       jcrop_options: jcrop_options.to_json

--- a/lib/active_admin_jcrop.rb
+++ b/lib/active_admin_jcrop.rb
@@ -6,3 +6,4 @@ require "formtastic/inputs/jcrop_input"
 require "active_admin_jcrop/engine"
 require "active_admin_jcrop/railtie"
 require 'active_admin_jcrop/image_helper'
+require 'active_admin_jcrop/view_helpers'

--- a/lib/active_admin_jcrop/railtie.rb
+++ b/lib/active_admin_jcrop/railtie.rb
@@ -15,8 +15,11 @@ module ActiveAdminJcrop
         ].each do |css|
           config.register_stylesheet css
         end
-        
+
       end
+    end
+    initializer "active_admin_jcrop_railtie.view_helpers" do
+      ActionView::Base.send :include, ViewHelpers
     end
   end
 

--- a/lib/active_admin_jcrop/view_helpers.rb
+++ b/lib/active_admin_jcrop/view_helpers.rb
@@ -1,0 +1,13 @@
+module ActiveAdminJcrop
+  module ViewHelpers
+
+    def jcropper_url(object)
+      partial_url = []
+      partial_url << ActiveAdmin.application.default_namespace
+      partial_url << object.class.to_s.demodulize.underscore
+
+      send("jcropper_#{partial_url.reject(&:blank?).join('_')}_path", object)
+    end
+
+  end
+end


### PR DESCRIPTION
I was having problems when ActiveAdmin's default_scope was false. It generated the following path: `jcropper_false_news_path`

With this PR it will only add the default_scope if not `blank?`. Now it generates the following path: `jcopper_news_path` which is correct.

I also added a `ViewHelpers` module to extract some complexity out of the view. 

Hope you like it, and merge it! ;)